### PR TITLE
Add Vue3 homepage demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# TK-public
+# Robot Ecommerce Homepage
+
+This repository contains a minimal Vue 3 application that demonstrates a single-page ecommerce homepage for a robot company. Components are loaded asynchronously and styled using Tailwind CSS via CDN. Open `index.html` in a modern browser to view the page.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>机器人企业独立站</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.1/dist/tailwind.min.css" rel="stylesheet">
+  <script type="importmap">
+  {
+    "imports": {
+      "vue": "https://unpkg.com/vue@3/dist/vue.esm-browser.prod.js"
+    }
+  }
+  </script>
+</head>
+<body class="bg-gray-50 text-gray-800">
+  <div id="app"></div>
+  <script type="module" src="./src/main.js"></script>
+</body>
+</html>

--- a/src/components/Banner.js
+++ b/src/components/Banner.js
@@ -1,0 +1,28 @@
+import { defineComponent, ref, onMounted } from 'vue';
+
+export default defineComponent({
+  name: 'BannerSection',
+  setup() {
+    const images = ref([
+      { id: 1, src: 'https://via.placeholder.com/1200x400?text=机器人+1' },
+      { id: 2, src: 'https://via.placeholder.com/1200x400?text=机器人+2' },
+      { id: 3, src: 'https://via.placeholder.com/1200x400?text=机器人+3' }
+    ]);
+    const current = ref(0);
+
+    onMounted(() => {
+      setInterval(() => {
+        current.value = (current.value + 1) % images.value.length;
+      }, 5000);
+    });
+
+    return { images, current };
+  },
+  template: `
+    <div class="relative w-full overflow-hidden">
+      <div v-for="(img, index) in images" :key="img.id" class="absolute inset-0 transition-opacity" :class="{ 'opacity-0': index !== current, 'opacity-100': index === current }">
+        <img :src="img.src" class="w-full h-60 md:h-96 object-cover" alt="banner" />
+      </div>
+    </div>
+  `
+});

--- a/src/components/BrandSection.js
+++ b/src/components/BrandSection.js
@@ -1,0 +1,11 @@
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'BrandSection',
+  template: `
+    <section class="bg-gray-100 py-8 px-4 text-center">
+      <h2 class="text-2xl font-bold mb-2">品牌故事</h2>
+      <p class="max-w-3xl mx-auto text-gray-600">我们致力于机器人技术的研发与应用，拥有丰富的行业经验与优秀的合作伙伴，为客户提供高质量的产品与服务。</p>
+    </section>
+  `
+});

--- a/src/components/CustomerReviews.js
+++ b/src/components/CustomerReviews.js
@@ -1,0 +1,23 @@
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'CustomerReviews',
+  setup() {
+    const reviews = [
+      { id: 1, company: '某大型制造企业', comment: '机器人稳定可靠，极大提升了生产效率。' },
+      { id: 2, company: '知名教育机构', comment: '教育机器人深受学生喜爱，编程教学效果显著。' }
+    ];
+    return { reviews };
+  },
+  template: `
+    <section class="bg-gray-50 py-8 px-4">
+      <h2 class="text-2xl font-bold mb-4 text-center">客户评价</h2>
+      <div class="max-w-3xl mx-auto space-y-4">
+        <div v-for="item in reviews" :key="item.id" class="border rounded-lg p-4">
+          <h3 class="font-semibold">{{ item.company }}</h3>
+          <p class="text-gray-600 text-sm mt-1">{{ item.comment }}</p>
+        </div>
+      </div>
+    </section>
+  `
+});

--- a/src/components/FooterSection.js
+++ b/src/components/FooterSection.js
@@ -1,0 +1,29 @@
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'FooterSection',
+  template: `
+    <footer class="bg-gray-800 text-gray-200 py-8 px-4 text-sm">
+      <div class="max-w-5xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div>
+          <h3 class="font-semibold mb-2">公司信息</h3>
+          <p>营业执照链接</p>
+          <p>ICP备案号</p>
+        </div>
+        <div>
+          <h3 class="font-semibold mb-2">快速导航</h3>
+          <ul>
+            <li><a href="#" class="hover:underline">机器人本体</a></li>
+            <li><a href="#" class="hover:underline">核心零部件</a></li>
+            <li><a href="#" class="hover:underline">租赁服务</a></li>
+          </ul>
+        </div>
+        <div>
+          <h3 class="font-semibold mb-2">联系方式</h3>
+          <p>邮箱: contact@example.com</p>
+          <p>微博 | 微信公众号 | B站</p>
+        </div>
+      </div>
+    </footer>
+  `
+});

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,0 +1,31 @@
+import { defineComponent, ref } from 'vue';
+
+export default defineComponent({
+  name: 'HeaderSection',
+  setup() {
+    const keywords = ref('');
+    const suggestions = ref([]);
+    function search() {
+      console.log('Searching:', keywords.value);
+      // TODO: connect to backend search API
+    }
+    return { keywords, suggestions, search };
+  },
+  template: `
+    <header class="bg-white shadow p-4 flex items-center justify-between">
+      <div class="text-xl font-bold">机器人企业</div>
+      <nav class="space-x-4 hidden md:block">
+        <a href="#" class="hover:text-blue-600">首页</a>
+        <a href="#" class="hover:text-blue-600">机器人本体</a>
+        <a href="#" class="hover:text-blue-600">核心零部件</a>
+        <a href="#" class="hover:text-blue-600">租赁服务</a>
+        <a href="#" class="hover:text-blue-600">解决方案</a>
+        <a href="#" class="hover:text-blue-600">关于我们</a>
+      </nav>
+      <div class="flex items-center space-x-2">
+        <input v-model="keywords" @keyup.enter="search" placeholder="搜索" class="border rounded px-2 py-1" />
+        <button @click="search" class="bg-blue-600 text-white px-3 py-1 rounded">搜索</button>
+      </div>
+    </header>
+  `
+});

--- a/src/components/ProductCard.js
+++ b/src/components/ProductCard.js
@@ -1,0 +1,20 @@
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'ProductCard',
+  props: {
+    product: Object
+  },
+  template: `
+    <div class="border rounded-lg p-4 hover:shadow-lg transition">
+      <img :src="product.img" class="w-full h-40 object-cover" alt="product" />
+      <h3 class="mt-2 font-semibold">{{ product.name }}</h3>
+      <p class="text-sm text-gray-500">{{ product.desc }}</p>
+      <div class="mt-2 flex justify-between items-center">
+        <span class="text-blue-600 font-bold" v-if="product.price">¥{{ product.price }}</span>
+        <button class="bg-blue-600 text-white px-3 py-1 rounded" v-else>立即咨询</button>
+        <button class="text-gray-500 hover:text-red-500" title="收藏">♥</button>
+      </div>
+    </div>
+  `
+});

--- a/src/components/ProductTabs.js
+++ b/src/components/ProductTabs.js
@@ -1,0 +1,38 @@
+import { defineComponent, ref } from 'vue';
+import ProductCard from './ProductCard.js';
+
+export default defineComponent({
+  name: 'ProductTabs',
+  components: { ProductCard },
+  setup() {
+    const tabs = [
+      { name: '机器人本体', key: 'body' },
+      { name: '零部件', key: 'parts' },
+      { name: '租赁服务', key: 'rent' }
+    ];
+    const active = ref('body');
+    const products = ref({
+      body: [
+        { id: 1, name: '人形机器人', desc: '多功能人形机器人', price: '5999', img: 'https://via.placeholder.com/200x160?text=Robot' },
+        { id: 2, name: '协作机械臂', desc: '适用于工业制造', price: '8999', img: 'https://via.placeholder.com/200x160?text=Arm' }
+      ],
+      parts: [
+        { id: 3, name: '伺服电机', desc: '高精度电机', price: '399', img: 'https://via.placeholder.com/200x160?text=Motor' }
+      ],
+      rent: [
+        { id: 4, name: '机器人租赁', desc: '短期租赁方案', price: null, img: 'https://via.placeholder.com/200x160?text=Rent' }
+      ]
+    });
+    return { tabs, active, products };
+  },
+  template: `
+    <section class="my-8 px-4">
+      <div class="flex space-x-4 border-b">
+        <button v-for="tab in tabs" :key="tab.key" @click="active = tab.key" :class="['py-2', active === tab.key ? 'border-b-2 border-blue-600 text-blue-600' : 'text-gray-500']">{{ tab.name }}</button>
+      </div>
+      <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 mt-4">
+        <ProductCard v-for="item in products[active]" :key="item.id" :product="item" />
+      </div>
+    </section>
+  `
+});

--- a/src/components/TechShowcase.js
+++ b/src/components/TechShowcase.js
@@ -1,0 +1,26 @@
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'TechShowcase',
+  setup() {
+    const scenes = [
+      { id: 1, title: '教育场景', img: 'https://via.placeholder.com/300x200?text=Edu', desc: '助力教育机器人解决方案' },
+      { id: 2, title: '智能制造', img: 'https://via.placeholder.com/300x200?text=Factory', desc: '协作机器人提升产能' },
+      { id: 3, title: '家庭服务', img: 'https://via.placeholder.com/300x200?text=Home', desc: '贴心家庭机器人' },
+      { id: 4, title: '医疗辅助', img: 'https://via.placeholder.com/300x200?text=Medical', desc: '手术辅助与康复机器人' }
+    ];
+    return { scenes };
+  },
+  template: `
+    <section class="py-8 px-4">
+      <h2 class="text-2xl font-bold mb-4 text-center">技术与应用场景</h2>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div v-for="item in scenes" :key="item.id" class="border rounded-lg p-4 flex flex-col items-center text-center">
+          <img :src="item.img" class="w-full h-40 object-cover" alt="scene" />
+          <h3 class="mt-2 font-semibold">{{ item.title }}</h3>
+          <p class="text-sm text-gray-500">{{ item.desc }}</p>
+        </div>
+      </div>
+    </section>
+  `
+});

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,33 @@
+import { createApp, defineAsyncComponent } from 'vue';
+
+const App = {
+  template: `
+    <div>
+      <HeaderSection />
+      <BannerSection />
+      <ProductTabs />
+      <BrandSection />
+      <TechShowcase />
+      <CustomerReviews />
+      <FooterSection />
+    </div>
+  `
+};
+
+const HeaderSection = defineAsyncComponent(() => import('./components/Header.js'));
+const BannerSection = defineAsyncComponent(() => import('./components/Banner.js'));
+const ProductTabs = defineAsyncComponent(() => import('./components/ProductTabs.js'));
+const BrandSection = defineAsyncComponent(() => import('./components/BrandSection.js'));
+const TechShowcase = defineAsyncComponent(() => import('./components/TechShowcase.js'));
+const CustomerReviews = defineAsyncComponent(() => import('./components/CustomerReviews.js'));
+const FooterSection = defineAsyncComponent(() => import('./components/FooterSection.js'));
+
+createApp(App)
+  .component('HeaderSection', HeaderSection)
+  .component('BannerSection', BannerSection)
+  .component('ProductTabs', ProductTabs)
+  .component('BrandSection', BrandSection)
+  .component('TechShowcase', TechShowcase)
+  .component('CustomerReviews', CustomerReviews)
+  .component('FooterSection', FooterSection)
+  .mount('#app');


### PR DESCRIPTION
## Summary
- add basic Vue 3 + Tailwind homepage using CDN modules
- create simple components for header, banner, product tabs, brand section, tech showcase, customer reviews and footer
- update README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ab2057e1083258b45fc4ec05df610